### PR TITLE
Fix compose file versions and host address alias

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-start-dependecies:
+start-dependencies:
 	$(info Make: Starting Tyk dashboard and dependecies)
 	docker-compose --env-file .env -f ci/tyk_dashboard.yml up &
 	sleep 5 
@@ -13,7 +13,7 @@ execute-tests:
 	$(info Make: Executing tests)
 	rm -fr results
 	docker-compose -f docker-compose-test.yml up
-stop-dependecies:
+stop-dependencies:
 	$(info Make: Starting Tyk dashboard and dependecies)
 	docker network rm tyk-test &
 	docker-compose --env-file .env -f ci/tyk_dashboard.yml down -v --remove-orphans &

--- a/ci/full_env.yml
+++ b/ci/full_env.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: '3.5'
 services:
     portal:
         container_name: portal

--- a/ci/keycloak.yml
+++ b/ci/keycloak.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: '3.5'
 services:
     keycloak-postgres:
         image: postgres:10-alpine

--- a/ci/tyk_analytics.conf
+++ b/ci/tyk_analytics.conf
@@ -136,6 +136,7 @@
     "sso_enable_user_lookup": false,
     "notifications_listen_port": 5000,
     "portal_session_lifetime": 0,
+    "enable_hashed_keys_listing": true,
     "enable_delete_key_by_hash": true,
     "enable_update_key_by_hash": true,
     "audit": {

--- a/ci/tyk_dashboard.yml
+++ b/ci/tyk_dashboard.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: '3.5'
 services:
     tyk-dashboard:
         container_name: tyk-dashboard-local
@@ -73,6 +73,7 @@ services:
     keycloak: 
         image: jboss/keycloak:16.1.0
         container_name: keycloak
+        restart: on-failure:5
         environment:
             # - KEYCLOAK_USER=admin
             # - KEYCLOAK_PASSWORD=admin

--- a/docker-compose-prerequisits.yml
+++ b/docker-compose-prerequisits.yml
@@ -1,4 +1,4 @@
-version: "3.4"
+version: "3.5"
 services:
   e2e:
     image: e2e-test
@@ -13,6 +13,8 @@ services:
       - HOST_IP=${HOST_IP}
       - ARA_TYK=${ARA_TYK}
     command: "npm run docker-prerequisits"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"    
 
 networks:
   default:

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,4 +1,4 @@
-version: "3.4"
+version: "3.5"
 services:
   e2e:
     image: e2e-test

--- a/local_env.yml
+++ b/local_env.yml
@@ -1,4 +1,4 @@
-version: "3.4"
+version: "3.5"
 services:
   tyk-dashboard:
       container_name: tyk-dashboard-local

--- a/selenium-grid.yml
+++ b/selenium-grid.yml
@@ -7,6 +7,8 @@ services:
       - selenium-hub
     networks:
       - tyk-test
+    extra_hosts:
+      - "host.docker.internal:host-gateway"           
     environment:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442


### PR DESCRIPTION
# Changes

## Fix docker-compose file versions
Bumped docker-compose versions to 3.5 to support the `name` attribute in network

## Small typo in makefile 
`dependencies` was misspelt

## Add `extra_hosts` to compose files to support `host.docker.internal`
`host.docker.internal` works fine on Mac or Windows but doesn't in Linux. The workaround to make it work in all environments is to add an `extra_hosts` mapping to  "host.docker.internal:host-gateway"
```yaml 
version: "3.5"
services:
   ... 
   image: ubuntu
    extra_hosts:
      - "host.docker.internal:host-gateway"
```
reference: https://medium.com/@TimvanBaarsen/how-to-connect-to-the-docker-host-from-inside-a-docker-container-112b4c71bc66

## Add `enable_hashed_keys_listing` to analytics conf file to list keys in dashboard
This way a dev can see all existing keys in the dashboard

## Add restart setting to keycloak container
Just in case, I saw one time keycloak not starting because of postgress failure or delay in loading
